### PR TITLE
[NO-ISSUE] Apply corrections to spelling mistakes

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -2,7 +2,7 @@
 
 `mani` currently only has integration tests, which require `docker` to run. This is because `mani` mainly interacts with the filesystem, and whilst there are ways to mock the filesystem, it's simply easier (and fast enough) to spin up a `docker` container and do the work there.
 
-The tests are based on something called "golden files", which are the expected output of the tests. It serves the benefit of working as documenation as well, since it becomes easy to see the desired output of the different `mani` commands.
+The tests are based on something called "golden files", which are the expected output of the tests. It serves the benefit of working as documentation as well, since it becomes easy to see the desired output of the different `mani` commands.
 
 There's some helpful scripts in the `scripts` directory that can be used to test and debug `mani`. These scripts should be run from the project directory.
 

--- a/test/integration/golden/completion/powershell/stdout.golden
+++ b/test/integration/golden/completion/powershell/stdout.golden
@@ -161,7 +161,7 @@ Register-ArgumentCompleter -CommandName 'mani' -ScriptBlock {
 
     $Values | ForEach-Object {
 
-        # store temporay because switch will overwrite $_
+        # store temporary because switch will overwrite $_
         $comp = $_
 
         # PowerShell supports three different completion modes
@@ -216,7 +216,7 @@ Register-ArgumentCompleter -CommandName 'mani' -ScriptBlock {
             Default {
                 # Like MenuComplete but we don't want to add a space here because
                 # the user need to press space anyway to get the completion.
-                # Description will not be shown because thats not possible with TabCompleteNext
+                # Description will not be shown because that's not possible with TabCompleteNext
                 [System.Management.Automation.CompletionResult]::new($($comp.Name | __mani_escapeStringWithSpecialChars), "$($comp.Name)", 'ParameterValue', "$($comp.Description)")
             }
         }

--- a/test/integration/main_test.go
+++ b/test/integration/main_test.go
@@ -94,7 +94,7 @@ func (tf *TestFile) AsFile() *os.File {
 }
 
 func clearGolden(goldenDir string) {
-	// Guard against accidently deleting outside directory
+	// Guard against accidentally deleting outside directory
 	if strings.Contains(goldenDir, "golden") {
 		os.RemoveAll(goldenDir)
 	}

--- a/test/scripts/exec
+++ b/test/scripts/exec
@@ -39,7 +39,7 @@ function parse_options() {
         help && exit 0
         ;;
       *)
-        printf "Unkown flag: ${1}\n\n"
+        printf "Unknown flag: ${1}\n\n"
         help
         exit 1
         ;;

--- a/test/scripts/test
+++ b/test/scripts/test
@@ -65,7 +65,7 @@ function parse_options() {
         help && exit 0
         ;;
       *)
-        printf "Unkown flag: ${1}\n\n"
+        printf "Unknown flag: ${1}\n\n"
         help
         exit 1
         ;;


### PR DESCRIPTION
### What's Changed

Applies corrections for spelling mistakes

### Technical Description

Using codespell common spelling mistakes can be found and correct using `codespell` to show the errors and `codespell -w` to automatically apply the fixes.  

see: https://github.com/codespell-project/codespell