### PR TITLE
[NO-ISSUE] enhances templates used by repository

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -20,4 +20,3 @@
     - [ ] fish
 
 ## Problem / Steps to reproduce
-

--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Suggest an feature for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is.
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,9 @@
+### What's Changed
+
+A description of the issue/feature; reference the issue number (if one exists). The Pull Request should not include fixes for issues other than the main issue/feature request.
+
+### Technical Description
+
+Any specific technical detail that may provide additional context to aid code review.
+
+> Before opening a Pull Request you should read and agreed to the Contributor Code of Conduct (see `CONTRIBUTING.md`\)


### PR DESCRIPTION
### What's Changed

fixes outdated issue template workflow: see https://github.com/alajmo/mani/blob/main/.github/ISSUE_TEMPLATE.md and adds a pull request template (used here)

### Technical Description

uses the latest workflow for reporting bugs/requesting features as outlined in https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates and adds a common pull request template that will be pre-populated in all new pull requests.

This will also enable the https://github.com/alajmo/mani/community to be populated successfully.