### PR TITLE
Feat/shell

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -18,6 +18,9 @@ make build-all
 
 # Build mani and get an interactive docker shell with completion
 make build-exec
+
+# Standing in _example directory you can run the following to debug faster
+(cd .. && make build-and-link && cd - && ../dist/mani run multi -p template-generator)
 ```
 
 ### Releasing

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,12 @@ build-test:
 build-exec:
 	./test/scripts/exec
 
+build-and-link:
+	go build \
+	-ldflags "-w -X ${PACKAGE}/cmd.version=${VERSION} -X ${PACKAGE}/cmd.commit=${GIT} -X ${PACKAGE}/cmd.date=${DATE}" \
+	-a -tags netgo -o dist/${NAME} main.go
+	cp ./dist/mani ~/.local/bin/mani
+
 release:
 	git tag ${VERSION} && git push origin ${VERSION}
 

--- a/_example/.gitignore
+++ b/_example/.gitignore
@@ -3,7 +3,7 @@ outside
 # mani-projects #
 template-generator
 frontend/dashgrid
-frontend/pinto-vim
+frontend/pinto
 # mani-projects #
 
 outside

--- a/_example/mani.yaml
+++ b/_example/mani.yaml
@@ -18,7 +18,14 @@ projects:
     tags:
       - bash
 
+shell: bash -c
+
 commands:
+  - name: print-hello-world
+    shell: node -e
+    command: |
+      console.log("Hello World")
+
   - name: fetch
     command: git fetch
 
@@ -35,5 +42,5 @@ commands:
 
   - name: multi
     command: | #Multi line command
-      echo "2nd line "
-      echo "3rd line"
+      echo "1st line "
+      echo "2nd line"

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -94,7 +94,7 @@ func executeCmd(args []string, configFile *string, dryRunFlag bool, cwdFlag bool
 
 	cmd := strings.Join(args[0:], " ")
 	for _, project := range finalProjects {
-		err := core.ExecCmd(configPath, project, cmd, dryRunFlag)
+		err := core.ExecCmd(configPath, config.Shell, project, cmd, dryRunFlag)
 
 		if err != nil {
 			fmt.Println(err)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -83,6 +83,13 @@ func executeRun(args []string, configFile *string, dryRunFlag bool, cwdFlag bool
 	core.CheckIfError(err)
 
 	command, err := core.GetCommand(args[0], config.Commands)
+
+	if command.Shell != "" {
+		config.Shell = command.Shell
+	}
+
+	core.CheckIfError(err)
+
 	if err != nil {
 		fmt.Println(err)
 		return
@@ -113,7 +120,7 @@ func executeRun(args []string, configFile *string, dryRunFlag bool, cwdFlag bool
 	userArguments := args[1:]
 	core.PrintCommand(command)
 	for _, project := range finalProjects {
-		err := core.RunCommand(configPath, project, command, userArguments, dryRunFlag)
+		err := core.RunCommand(configPath, config.Shell, project, command, userArguments, dryRunFlag)
 
 		if err != nil {
 			fmt.Println(err)

--- a/core/config.go
+++ b/core/config.go
@@ -12,10 +12,12 @@ type Command struct {
 	Name        string            `yaml:"name"`
 	Description string            `yaml:"description"`
 	Args        map[string]string `yaml:"args"`
+	Shell		string            `yaml:"shell"`
 	Command     string            `yaml:"command"`
 }
 
 type Config struct {
+	Shell    string    `yaml:"shell"`
 	Projects []Project `yaml:"projects"`
 	Commands []Command `yaml:"commands"`
 }


### PR DESCRIPTION
### What's Changed

Allow users to define their own shell command (currently it was hardcoded to `sh -c`). Now users can define programs on a global level (root level) and `Command` level, to invoke different shells or languages.