### PR TITLE
Enable mani edit even with malformed YAML

### DIFF
--- a/_example/README.md
+++ b/_example/README.md
@@ -14,6 +14,8 @@ projects:
     path: frontend/pinto
     url: https://github.com/alajmo/pinto.git
     desc: A vim theme editor
+    env:
+      default_branch: main
     tags: [frontend, node]
 
   dashgrid:

--- a/_site/docs/changelog.md
+++ b/_site/docs/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [UNRELEASED]
+
+- Enable `mani edit` to run even if config file is malformed (wrong YAML syntax)
+
 ## v0.11.1
 
 ### Features

--- a/cmd/edit.go
+++ b/cmd/edit.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	"github.com/spf13/cobra"
 
+	"fmt"
+
 	"github.com/alajmo/mani/core"
 	"github.com/alajmo/mani/core/dao"
 )
@@ -20,8 +22,19 @@ func editCmd(config *dao.Config, configErr *error) *cobra.Command {
   # Edit specific mani config
   edit edit --config path/to/mani/config`,
 		Run: func(cmd *cobra.Command, args []string) {
-			core.CheckIfError(*configErr)
-			runEdit(args, *config)
+			// TODO: Should handle all cases correctly, now it just handles cases
+			// when it can't find the config file, but what about permissions errors,
+			// Golang errors from GetWD, etc.
+			// Perhaps solution is to panic on those errors since something
+			// must have gone horribly wrong.
+			err := *configErr
+			fmt.Println(err)
+			switch e := err.(type) {
+			case *core.ConfigNotFound:
+				core.CheckIfError(e)
+			default:
+				runEdit(args, *config)
+			}
 		},
 	}
 
@@ -35,5 +48,5 @@ func editCmd(config *dao.Config, configErr *error) *cobra.Command {
 }
 
 func runEdit(args []string, config dao.Config) {
-	config.EditConfig()
+	// config.EditConfig()
 }

--- a/cmd/edit.go
+++ b/cmd/edit.go
@@ -3,8 +3,6 @@ package cmd
 import (
 	"github.com/spf13/cobra"
 
-	"fmt"
-
 	"github.com/alajmo/mani/core"
 	"github.com/alajmo/mani/core/dao"
 )
@@ -28,7 +26,6 @@ func editCmd(config *dao.Config, configErr *error) *cobra.Command {
 			// Perhaps solution is to panic on those errors since something
 			// must have gone horribly wrong.
 			err := *configErr
-			fmt.Println(err)
 			switch e := err.(type) {
 			case *core.ConfigNotFound:
 				core.CheckIfError(e)
@@ -48,5 +45,5 @@ func editCmd(config *dao.Config, configErr *error) *cobra.Command {
 }
 
 func runEdit(args []string, config dao.Config) {
-	// config.EditConfig()
+	config.EditConfig()
 }

--- a/cmd/edit_project.go
+++ b/cmd/edit_project.go
@@ -19,8 +19,13 @@ func editProject(config *dao.Config, configErr *error) *cobra.Command {
   # Edit project in specific mani config
   mani edit --config path/to/mani/config`,
 		Run: func(cmd *cobra.Command, args []string) {
-			core.CheckIfError(*configErr)
-			runEditProject(args, *config)
+			err := *configErr
+			switch e := err.(type) {
+			case *core.ConfigNotFound:
+				core.CheckIfError(e)
+			default:
+				runEdit(args, *config)
+			}
 		},
 		Args: cobra.MaximumNArgs(1),
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/cmd/edit_project.go
+++ b/cmd/edit_project.go
@@ -24,7 +24,7 @@ func editProject(config *dao.Config, configErr *error) *cobra.Command {
 			case *core.ConfigNotFound:
 				core.CheckIfError(e)
 			default:
-				runEdit(args, *config)
+				runEditProject(args, *config)
 			}
 		},
 		Args: cobra.MaximumNArgs(1),

--- a/cmd/edit_task.go
+++ b/cmd/edit_task.go
@@ -19,8 +19,13 @@ func editTask(config *dao.Config, configErr *error) *cobra.Command {
   # Edit task in specific mani config
   mani edit task status --config path/to/mani/config`,
 		Run: func(cmd *cobra.Command, args []string) {
-			core.CheckIfError(*configErr)
-			runEditTask(args, *config)
+			err := *configErr
+			switch e := err.(type) {
+			case *core.ConfigNotFound:
+				core.CheckIfError(e)
+			default:
+				runEdit(args, *config)
+			}
 		},
 		Args: cobra.MaximumNArgs(1),
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/cmd/edit_task.go
+++ b/cmd/edit_task.go
@@ -24,7 +24,7 @@ func editTask(config *dao.Config, configErr *error) *cobra.Command {
 			case *core.ConfigNotFound:
 				core.CheckIfError(e)
 			default:
-				runEdit(args, *config)
+				runEditTask(args, *config)
 			}
 		},
 		Args: cobra.MaximumNArgs(1),

--- a/core/dao/config.go
+++ b/core/dao/config.go
@@ -251,7 +251,10 @@ func dfs(n *core.Node, m map[string]*core.Node, cycles *[]core.NodeLink, ci *Con
 
 		nc.Imports = imports
 
-		dfs(&nc, m, cycles, ci)
+		err = dfs(&nc, m, cycles, ci)
+		if err != nil {
+			return err
+		}
 	}
 
 	n.Visiting = false

--- a/core/dao/config.go
+++ b/core/dao/config.go
@@ -122,7 +122,7 @@ func ReadConfig(cfgName string) (Config, error) {
 
 	configResources, err := config.importConfigs()
 	if err != nil {
-		return Config{}, err
+		return config, err
 	}
 
 	config.TaskList = configResources.Tasks
@@ -139,7 +139,6 @@ func ReadConfig(cfgName string) (Config, error) {
 
 	// Parse all tasks
 	for i := range configResources.Tasks {
-		// TODO
 		configResources.Tasks[i].ParseTask(config)
 	}
 
@@ -215,8 +214,6 @@ func dfs(n *core.Node, m map[string]*core.Node, cycles *[]core.NodeLink, ci *Con
 
 	for _, importPath := range n.Imports {
 		p, err := core.GetAbsolutePath(filepath.Dir(n.Path), importPath, "")
-		// TODO: Before it exited here if there was an error, but now I want to return
-		// the error
 		if err != nil {
 			return err
 		}

--- a/core/dao/config.go
+++ b/core/dao/config.go
@@ -107,30 +107,29 @@ func ReadConfig(cfgName string) (Config, error) {
 	// Found config, now try to read it
 	var config Config
 
-	err = yaml.Unmarshal(dat, &config)
-	if err != nil {
-		parseError := &core.FailedToParseFile{Name: configPath, Msg: err}
-		return config, parseError
-	}
-
 	config.Path = configPath
 	config.Dir = filepath.Dir(configPath)
+
+	err = yaml.Unmarshal(dat, &config)
+	if err != nil {
+		return config, &core.FailedToParseFile{Name: configPath, Msg: err}
+	}
 
 	// Set default shell command
 	if config.Shell == "" {
 		config.Shell = DEFAULT_SHELL
 	}
 
-	tasks, projects, dirs, themes, envs, err := config.importConfigs()
+	configResources, err := config.importConfigs()
 	if err != nil {
 		return Config{}, err
 	}
 
-	config.TaskList = tasks
-	config.ProjectList = projects
-	config.DirList = dirs
-	config.ThemeList = themes
-	config.EnvList = envs
+	config.TaskList = configResources.Tasks
+	config.ProjectList = configResources.Projects
+	config.DirList = configResources.Dirs
+	config.ThemeList = configResources.Themes
+	config.EnvList = configResources.Envs
 
 	// Set default config if it's not set already
 	_, err = config.GetTheme(DEFAULT_THEME.Name)
@@ -139,11 +138,44 @@ func ReadConfig(cfgName string) (Config, error) {
 	}
 
 	// Parse all tasks
-	for i := range tasks {
-		tasks[i].ParseTask(config)
+	for i := range configResources.Tasks {
+		// TODO
+		configResources.Tasks[i].ParseTask(config)
 	}
 
 	return config, nil
+}
+
+func (c Config) loadResources(ci *ConfigResources) error {
+	tasks, err := c.GetTaskList()
+	if err != nil {
+		return err
+	}
+
+	projects, err := c.GetProjectList()
+	if err != nil {
+		return err
+	}
+
+	dirs, err := c.GetDirList()
+	if err != nil {
+		return err
+	}
+
+	themes, err := c.GetThemeList()
+	if err != nil {
+		return err
+	}
+
+	envs := c.GetEnvList()
+
+	ci.Tasks = append(ci.Tasks, tasks...)
+	ci.Projects = append(ci.Projects, projects...)
+	ci.Dirs = append(ci.Dirs, dirs...)
+	ci.Themes = append(ci.Themes, themes...)
+	ci.Envs = append(ci.Envs, envs...)
+
+	return nil
 }
 
 // Given config imports, use a Depth-first-search algorithm to recursively
@@ -151,38 +183,30 @@ func ReadConfig(cfgName string) (Config, error) {
 // A struct is passed around that is populated with resources from each config.
 // In case a cyclic dependency is found (a -> b and b -> a), we return early and
 // with an error containing the cyclic dependency found.
-func (c Config) importConfigs() ([]Task, []Project, []Dir, []Theme, []string, error) {
+func (c Config) importConfigs() (ConfigResources, error) {
 	n := core.Node{
 		Path:    c.Path,
 		Imports: c.Import,
 	}
 
-	fmt.Println("----------------------")
-	core.DebugPrint(91919191)
-	fmt.Println("----------------------")
-
 	m := make(map[string]*core.Node)
 	m[n.Path] = &n
 	cycles := []core.NodeLink{}
-	// TODO/NEXT: Left of here, GetTaskList should return error
-	ci := ConfigResources{
-		Tasks:    c.GetTaskList(),
-		Projects: c.GetProjectList(),
-		Dirs:     c.GetDirList(),
-		Themes:   c.GetThemeList(),
-		Envs:     c.GetEnvList(),
+
+	ci := ConfigResources{}
+	err :=  c.loadResources(&ci)
+	if err != nil {
+		return ci, err
 	}
 
-	fmt.Println("----------------------")
-	core.DebugPrint("FAILED")
-	fmt.Println("----------------------")
+	err = dfs(&n, m, &cycles, &ci)
 
-	dfs(&n, m, &cycles, &ci)
-
-	if len(cycles) > 0 {
-		return []Task{}, []Project{}, []Dir{}, []Theme{}, []string{}, &core.FoundCyclicDependency{Cycles: cycles}
+	if err != nil {
+		return ci, err
+	} else if len(cycles) > 0 {
+		return ci, &core.FoundCyclicDependency{Cycles: cycles}
 	} else {
-		return ci.Tasks, ci.Projects, ci.Dirs, ci.Themes, ci.Envs, nil
+		return ci, nil
 	}
 }
 
@@ -223,16 +247,11 @@ func dfs(n *core.Node, m map[string]*core.Node, cycles *[]core.NodeLink, ci *Con
 		}
 
 		// Import Data
-		ts, ps, ds, thms, envs, imports, err := importConfig(nc.Path)
+		imports, err := importConfig(nc.Path, ci)
 		if err != nil {
 			return err
 		}
 
-		ci.Tasks = append(ci.Tasks, ts...)
-		ci.Projects = append(ci.Projects, ps...)
-		ci.Dirs = append(ci.Dirs, ds...)
-		ci.Themes = append(ci.Themes, thms...)
-		ci.Envs = append(ci.Envs, envs...)
 		nc.Imports = imports
 
 		dfs(&nc, m, cycles, ci)
@@ -244,36 +263,37 @@ func dfs(n *core.Node, m map[string]*core.Node, cycles *[]core.NodeLink, ci *Con
 	return nil
 }
 
-func importConfig(path string) ([]Task, []Project, []Dir, []Theme, []string, []string, error) {
+func importConfig(path string, ci *ConfigResources) ([]string, error) {
 	dat, err := ioutil.ReadFile(path)
 	if err != nil {
-		return []Task{}, []Project{}, []Dir{}, []Theme{}, []string{}, []string{}, err
+		return []string{}, err
 	}
 
 	absPath, err := filepath.Abs(path)
 	if err != nil {
-		return []Task{}, []Project{}, []Dir{}, []Theme{}, []string{}, []string{}, err
+		return []string{}, err
 	}
 
 	// Found config, now try to read it
 	var config Config
 	err = yaml.Unmarshal(dat, &config)
 	if err != nil {
-		parseError := &core.FailedToParseFile{Name: path, Msg: err}
-		return []Task{}, []Project{}, []Dir{}, []Theme{}, []string{}, []string{}, parseError
+		return []string{}, &core.FailedToParseFile{Name: path, Msg: err}
 	}
 
 	config.Path = absPath
 	config.Dir = filepath.Dir(absPath)
 
-	return config.GetTaskList(), config.GetProjectList(), config.GetDirList(), config.GetThemeList(), config.GetEnvList(), config.Import, nil
+	err = config.loadResources(ci)
+	if err != nil {
+		return []string{}, &core.FailedToParseFile{Name: path, Msg: err}
+	}
+
+	return config.Import, nil
 }
 
 // Open mani config in editor
 func (c Config) EditConfig() {
-	// fmt.Println("----------------------")
-	// fmt.Println(123)
-	// fmt.Println("----------------------")
 	openEditor(c.Path, -1)
 }
 

--- a/core/dao/project.go
+++ b/core/dao/project.go
@@ -69,12 +69,12 @@ func (c *Config) GetProjectList() ([]Project, error) {
 		// Add absolute and relative path for each project
 		project.Path, err = core.GetAbsolutePath(c.Dir, project.Path, project.Name)
 		if err != nil {
-			return []Project{}, &core.FailedToParseFile{Name: c.Path, Msg: err}
+			return []Project{}, err
 		}
 
 		project.RelPath, err = core.GetRelativePath(c.Dir, project.Path)
 		if err != nil {
-			return []Project{}, &core.FailedToParseFile{Name: c.Path, Msg: err}
+			return []Project{}, err
 		}
 
 		envList, err := core.EvaluateEnv(core.GetEnv(project.Env))

--- a/core/dao/project.go
+++ b/core/dao/project.go
@@ -52,7 +52,7 @@ func (p Project) GetValue(key string) string {
 	return ""
 }
 
-func (c *Config) GetProjectList() []Project {
+func (c *Config) GetProjectList() ([]Project, error) {
 	var projects []Project
 	count := len(c.Projects.Content)
 
@@ -60,29 +60,36 @@ func (c *Config) GetProjectList() []Project {
 	for i := 0; i < count; i += 2 {
 		project := &Project{}
 		err = c.Projects.Content[i+1].Decode(project)
-		core.CheckIfError(err)
+		if err != nil {
+			return []Project{}, &core.FailedToParseFile{Name: c.Path, Msg: err}
+		}
 
 		project.Name = c.Projects.Content[i].Value
 
 		// Add absolute and relative path for each project
-		var err error
 		project.Path, err = core.GetAbsolutePath(c.Dir, project.Path, project.Name)
-		core.CheckIfError(err)
+		if err != nil {
+			return []Project{}, &core.FailedToParseFile{Name: c.Path, Msg: err}
+		}
 
 		project.RelPath, err = core.GetRelativePath(c.Dir, project.Path)
-		core.CheckIfError(err)
-
-		project.Context = c.Path
+		if err != nil {
+			return []Project{}, &core.FailedToParseFile{Name: c.Path, Msg: err}
+		}
 
 		envList, err := core.EvaluateEnv(core.GetEnv(project.Env))
-		core.CheckIfError(err)
+		if err != nil {
+			return []Project{}, &core.FailedToParseFile{Name: c.Path, Msg: err}
+		}
 
 		project.EnvList = envList
+
+		project.Context = c.Path
 
 		projects = append(projects, *project)
 	}
 
-	return projects
+	return projects, nil
 }
 
 func (c Config) CloneRepos(parallel bool) {

--- a/core/dao/run.go
+++ b/core/dao/run.go
@@ -129,6 +129,7 @@ func (t Task) tableWork(
 		var err error
 		output, err = RunTable(*config, cmd.Cmd, cmd.EnvList, cmd.Shell, entity, dryRunFlag)
 		// TODO: Thread safety? Perhaps re-write this
+		// TODO: Also, if project path does not exist, no error is shown, which can be confusing
 		data.Rows[i] = append(data.Rows[i], strings.TrimSuffix(output, "\n"))
 
 		if err != nil && !t.IgnoreError {

--- a/core/dao/task.go
+++ b/core/dao/task.go
@@ -185,19 +185,20 @@ func (t Task) GetValue(key string) string {
 	return ""
 }
 
-func (c *Config) GetTaskList() []Task {
+func (c *Config) GetTaskList() ([]Task, error) {
 	var tasks []Task
 	count := len(c.Tasks.Content)
 
-	var err error
 	for i := 0; i < count; i += 2 {
 		task := &Task{}
 
 		if c.Tasks.Content[i+1].Kind == 8 {
 			task.Cmd = c.Tasks.Content[i+1].Value
 		} else {
-			err = c.Tasks.Content[i+1].Decode(task)
-			core.CheckIfError(err)
+			err := c.Tasks.Content[i+1].Decode(task)
+			if err != nil {
+				return []Task{}, &core.FailedToParseFile{Name: c.Path, Msg: err}
+			}
 		}
 
 		// Add context to each task
@@ -207,7 +208,7 @@ func (c *Config) GetTaskList() []Task {
 		tasks = append(tasks, *task)
 	}
 
-	return tasks
+	return tasks, nil
 }
 
 func GetEnvList(env yaml.Node, userEnv []string, parentEnv []string, configEnv []string) []string {

--- a/core/dao/theme.go
+++ b/core/dao/theme.go
@@ -11,21 +11,22 @@ type Theme struct {
 }
 
 // Populates ThemeList and creates a default theme if no default theme is set.
-func (c *Config) GetThemeList() []Theme {
+func (c *Config) GetThemeList() ([]Theme, error) {
 	var themes []Theme
-	var err error
 	count := len(c.Themes.Content)
 
 	for i := 0; i < count; i += 2 {
 		theme := &Theme{}
-		err= c.Themes.Content[i+1].Decode(theme)
-		core.CheckIfError(err)
+		err := c.Themes.Content[i+1].Decode(theme)
+		if err != nil {
+			return []Theme{}, &core.FailedToParseFile{Name: c.Path, Msg: err}
+		}
 
 		theme.Name = c.Themes.Content[i].Value
 		themes = append(themes, *theme)
 	}
 
-	return themes
+	return themes, nil
 }
 
 func (c Config) GetTheme(name string) (*Theme, error) {

--- a/core/errors.go
+++ b/core/errors.go
@@ -57,17 +57,17 @@ func (f *MissingFile) Error() string {
 	return fmt.Sprintf("error: missing %q", f.Name)
 }
 
-type FailedToParseFile struct {
-	Name string
-	Msg  error
-}
-
 type FailedToParsePath struct {
 	Name string
 }
 
 func (f *FailedToParsePath) Error() string {
 	return fmt.Sprintf("error: failed to parse path %q", f.Name)
+}
+
+type FailedToParseFile struct {
+	Name string
+	Msg  error
 }
 
 func (f *FailedToParseFile) Error() string {

--- a/test/playground/mani.yaml
+++ b/test/playground/mani.yaml
@@ -1,5 +1,5 @@
-# import:
-#   - ./tmp/mani.yaml
+import:
+  - ./tmp/mani.yaml
 
 projects:
   example:
@@ -12,7 +12,6 @@ projects:
     tags: [frontend]
     env:
       branch: lala
-      # branch: $(echo 123)
 
   dashgrid:
     path: frontend/dashgrid
@@ -21,7 +20,7 @@ projects:
     desc: A highly customizable drag-and-drop grid
     tags: [frontend, kaka]
     env:
-      branch: $(date +%s%N)
+      branch: hello
 
   template-generator:
     url: git@github.com:alajmo/template-generator
@@ -32,7 +31,6 @@ env:
   DATE: $(date -u +"%Y-%m-%dT%H:%M:%S%Z")
   VERSION: v5.1.0
   GIT: git --no-pager
-  hejsan: $(echo 123)
 
 themes:
   default:
@@ -45,9 +43,6 @@ themes:
 
 tasks:
   test:
-    env:
-      branch: $(echo $MANPATH)
-    # output: text
     cmd: echo $branch
 
   echo:

--- a/test/playground/mani.yaml
+++ b/test/playground/mani.yaml
@@ -1,5 +1,5 @@
 import:
-  - ./tmp/mani.yaml
+  - ./tmp/projects.yaml
 
 projects:
   example:

--- a/test/playground/mani.yaml
+++ b/test/playground/mani.yaml
@@ -1,5 +1,5 @@
-import:
-  - ./tmp/mani.yaml
+# import:
+#   - ./tmp/mani.yaml
 
 projects:
   example:
@@ -11,7 +11,7 @@ projects:
     desc: A tap report theme
     tags: [frontend]
     env:
-      branch: $(date +%s%N)
+      branch: lala
       # branch: $(echo 123)
 
   dashgrid:

--- a/test/playground/tmp/mani.yaml
+++ b/test/playground/tmp/mani.yaml
@@ -1,4 +1,4 @@
-import:
+import
   - ./tasks.yaml
 
 projects:
@@ -7,5 +7,4 @@ projects:
     desc: A simple bash script used to manage boilerplates
     tags: [frontend, cli, bash]
     env:
-      # branch: lala
-      branch: $(echo 123)
+      branch: hejsan

--- a/test/playground/tmp/projects.yaml
+++ b/test/playground/tmp/projects.yaml
@@ -1,4 +1,4 @@
-import
+import:
   - ./tasks.yaml
 
 projects:

--- a/test/playground/tmp/tasks.yaml
+++ b/test/playground/tmp/tasks.yaml
@@ -1,10 +1,9 @@
 tasks:
   hej:
-    description: hello world
-    command: |
-      echo 123
+    desc: hello world
+    cmd: echo 123
 
   inherit:
-    command: |
+    cmd: |
       echo 123
       pwd


### PR DESCRIPTION
### What's Changed

Enable `mani edit` even if there is config file is malformed (YAML error), see https://github.com/alajmo/mani/issues/18.

### Technical Description

Part of the fix is to do error handling properly, now `mani` is crashing as soon as an error is found.
