### PR TITLE
Add silent option to run/exec sub-commands

### DIFF
--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -46,6 +46,7 @@ before the command gets executed in each directory.`,
 	}
 
 	cmd.Flags().BoolVar(&runFlags.DryRun, "dry-run", false, "prints the command to see what will be executed")
+	cmd.Flags().BoolVarP(&runFlags.Silent, "silent", "s", false, "do not show progress when running tasks")
 	cmd.Flags().BoolVar(&runFlags.OmitEmpty, "omit-empty", false, "omit empty results")
 	cmd.Flags().BoolVar(&runFlags.Parallel, "parallel", false, "run tasks in parallel for each project")
 	cmd.Flags().StringVarP(&runFlags.Output, "output", "o", "", "set output [text|table|markdown|html]")

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -62,6 +62,7 @@ The tasks are specified in a mani.yaml file along with the projects you can targ
 
 	cmd.Flags().BoolVar(&runFlags.Describe, "describe", false, "print task information")
 	cmd.Flags().BoolVar(&runFlags.DryRun, "dry-run", false, "prints the task to see what will be executed")
+	cmd.Flags().BoolVarP(&runFlags.Silent, "silent", "s", false, "do not show progress when running tasks")
 	cmd.Flags().BoolVar(&runFlags.OmitEmpty, "omit-empty", false, "omit empty results")
 	cmd.Flags().BoolVar(&runFlags.Parallel, "parallel", false, "run tasks in parallel for each project")
 	cmd.Flags().BoolVarP(&runFlags.Edit, "edit", "e", false, "edit task")

--- a/core/exec/exec.go
+++ b/core/exec/exec.go
@@ -61,7 +61,7 @@ func (exec *Exec) Run(
 
 	switch tasks[0].SpecData.Output {
 	case "table", "html", "markdown":
-		data := exec.Table(runFlags.DryRun)
+		data := exec.Table(runFlags)
 		options := print.PrintTableOptions{Theme: tasks[0].ThemeData, OmitEmpty: tasks[0].SpecData.OmitEmpty, Output: tasks[0].SpecData.Output, SuppressEmptyColumns: false}
 		print.PrintTable(data.Rows, options, data.Headers[0:1], data.Headers[1:])
 	default:

--- a/core/flags.go
+++ b/core/flags.go
@@ -28,6 +28,7 @@ type RunFlags struct {
 	Edit     bool
 	Parallel bool
 	DryRun   bool
+	Silent   bool
 	Describe bool
 	Cwd      bool
 	Theme    string

--- a/core/mani.1
+++ b/core/mani.1
@@ -69,6 +69,9 @@ target projects by paths
 \fB-p, --projects=[]\fR
 target projects by names
 .TP
+\fB-s, --silent[=false]\fR
+do not show progress when running tasks
+.TP
 \fB-t, --tags=[]\fR
 target projects by tags
 .TP
@@ -112,6 +115,9 @@ target projects by paths
 .TP
 \fB-p, --projects=[]\fR
 target projects by names
+.TP
+\fB-s, --silent[=false]\fR
+do not show progress when running tasks
 .TP
 \fB-t, --tags=[]\fR
 target projects by tags

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,7 @@
 
 - Add filter options to sub-command sync #46
 - Add check sub-command to validate mani config
+- Add option to disable spinner when running tasks
 
 ## 0.21.0
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -69,6 +69,7 @@ run <task>
       --parallel           run tasks in parallel for each project
   -d, --paths strings      target projects by paths
   -p, --projects strings   target projects by names
+  -s, --silent             do not show progress when running tasks
   -t, --tags strings       target projects by tags
       --theme string       set theme
 ```
@@ -111,6 +112,7 @@ exec <command> [flags]
       --parallel           run tasks in parallel for each project
   -d, --paths strings      target projects by paths
   -p, --projects strings   target projects by names
+  -s, --silent             do not show progress when running tasks
   -t, --tags strings       target projects by tags
       --theme string       set theme (default "default")
 ```

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,11 +2,11 @@
 
 `mani` is under active development. Before **v1.0.0**, I want to finish the following tasks, some miscellaneous fixes and improve code documentation:
 
-- [ ] Add filter tags/projects/paths for `mani sync`
-- [ ] Add check sub-command
-- [ ] Add a way to disable spinner on run/exec sub-commands
-- [ ] Fix NO_COLOR for `mani init`
+- [x] Add filter tags/projects/paths for `mani sync`
+- [x] Add check sub-command
+- [x] Add a way to disable spinner on run/exec sub-commands
 - [ ] Add root flag/target to target root mani directory
+
 - [ ] Bring changes from `sake`
   - Add auto-complete description for editing/listing/describing projects
   - Refactor import logic and support recursive nesting of tasks
@@ -14,13 +14,10 @@
   - Fix correct exit code for tasks
   - Remove `commands` and put functionality in `cmd` property which will accepts string or list of tasks/cmds
   - Add flag ignore-errors and any-errors-fatal
-- [ ] Add task aliases
-- [ ] Add project/task dependency (dependsOn), to wait for certain projects to finish before starting tasks for other projects
 - [ ] Update documentation
   - markdown docs
   - manpage
 - [ ] Fix windows environment variables
-
 
 - [ ] Improve output
   - Add new table format output (tasks in 1st column, output in 2nd, one table per server)
@@ -44,6 +41,8 @@
   - [ ] Abort if certain env variables are not present (required envs)
   - [ ] Add --step mode flag or config setting to prompt before executing a task
   - [ ] Add yaml to command mapper
+  - [ ] Add task aliases
+  - [ ] Add project/task dependency (dependsOn), to wait for certain projects to finish before starting tasks for other projects
 
 ## Future
 

--- a/test/playground/mani.yaml
+++ b/test/playground/mani.yaml
@@ -50,8 +50,8 @@ tasks:
     cmd: echo pong
 
   sleep:
-    desc: Sleep 5 seconds
-    cmd: sleep 5
+    desc: Sleep 2 seconds
+    cmd: sleep 2 && echo "slept 2 seconds"
 
   status:
     desc: git status


### PR DESCRIPTION
### What's Changed

Add silent option to run/exec sub-commands (will disable spinner). Useful when you want to pipe command execution to a file or in CI environments. See #44.