### PR TITLE
Add Extended CmdArgs support

### DIFF
--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -150,7 +150,7 @@ func execute(
 		}
 
 		target := exec.Exec{Projects: projects, Tasks: tasks, Config: *config}
-		err := target.Run([]string{}, runFlags, setRunFlags)
+		err := target.Run([]string{}, []string{}, runFlags, setRunFlags)
 		core.CheckIfError(err)
 	}
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -142,11 +142,13 @@ func run(
 	var cmdArgs []string
 	// Separate user arguments from task names
 	for _, arg := range args {
-		if strings.Contains(arg, "=") && !strings.HasPrefix(arg, "-") && len(cmdArgs) == 0 {
+		if len(cmdArgs) > 0 {
+			cmdArgs = append(cmdArgs, arg)
+		} else if strings.Contains(arg, "=") && !strings.HasPrefix(arg, "-") {
 			userArgs = append(userArgs, arg)
 		} else {
 			task, err := config.GetTask(arg)
-			if err != nil || len(cmdArgs) > 0 {
+			if err != nil {
 				cmdArgs = append(cmdArgs, arg)
 			} else {
 				taskDefinitions = append(taskDefinitions, task)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -142,9 +142,9 @@ func run(
 	var cmdArgs []string
 	// Separate user arguments from task names
 	for _, arg := range args {
-		if strings.Contains(arg, "=") {
+		if strings.Contains(arg, "=") && !strings.HasPrefix(arg, "-") && len(cmdArgs) == 0 {
 			userArgs = append(userArgs, arg)
-		} else if len(userArgs) == 0 {
+		} else {
 			task, err := config.GetTask(arg)
 			if err != nil || len(cmdArgs) > 0 {
 				cmdArgs = append(cmdArgs, arg)


### PR DESCRIPTION
### What's Changed

The change makes it possible to easily add any parameters to defined tasks. This can best be explained with an example

I would like to have a task `pull` to install all dependencies. Additionally I would like to use the same task to install a single dependency

> mani.yaml
```
tasks:
  npm-install:
    desc: run npm install in node repos
    target:
      tags: [node]
    cmd: npm install
projects:
  ...
```

```
mani run npm-install
mani run npm-install @my/dependency
```

Currently, I would have to define a new task `npm-install-dep` for this use case. This change also becomes practical for commands like `git pull` where I use different combinations of arguments

### Technical Description

I can also adjust the tests/ documentation in this PR. But I wanted to hear your opinion first. If necessary, you can simplify the implementation or provide me some hints to improve. I am a newbie in go
