### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,9 @@ Interested in managing your servers in a similar way? Checkout [sake](https://gi
   sudo port install mani
   ```
 
-* via Arch
+* via Arch (AUR)
   ```sh
-  pacman -S mani
+  yay -S mani
   ```
 
 * via Nix


### PR DESCRIPTION
mani is not available in the standard pacman repo. It's available in the AUR, though.

### What's Changed

I fixed the installation instructions for arch linux

### Technical Description

I adopted the `mani` package in the AUR. Realized the installation instructions for arch, in your README.md won't work. The new command will do the trick.
