### PR TITLE
Add glob pattern support to paths

### DIFF
--- a/core/dao/project.go
+++ b/core/dao/project.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -321,6 +322,9 @@ func (c Config) GetProjectsByName(projectNames []string) ([]Project, error) {
 // Projects must have all dirs to match.
 // If user provides a path which does not exist, then return error containing
 // all the paths it didn't find.
+// Supports glob patterns:
+// - '*' matches any sequence of non-separator characters
+// - '**' matches any sequence of characters including separators
 func (c Config) GetProjectsByPath(dirs []string) ([]Project, error) {
 	if len(dirs) == 0 {
 		return c.ProjectList, nil
@@ -336,9 +340,59 @@ func (c Config) GetProjectsByPath(dirs []string) ([]Project, error) {
 		// Variable use to check that all dirs are matched
 		var numMatched = 0
 		for _, dir := range dirs {
-			if strings.Contains(project.RelPath, dir) {
+
+			matchPath := func(dir string, path string) (bool, error) {
+				// Handle glob pattern
+				if strings.Contains(dir, "*") {
+					// Handle '**' glob pattern
+					if strings.Contains(dir, "**") {
+						// Convert the glob pattern to a regex pattern
+						regexPattern := strings.ReplaceAll(dir, "**/", "<glob>")
+						regexPattern = strings.ReplaceAll(regexPattern, "*", "[^/]*")
+						regexPattern = strings.ReplaceAll(regexPattern, "?", ".")
+						regexPattern = strings.ReplaceAll(regexPattern, "<glob>", "(.*/)*")
+						regexPattern = "^" + regexPattern + "$"
+
+						matched, err := regexp.MatchString(regexPattern, project.RelPath)
+
+						if err != nil {
+							return false, err
+						}
+
+						if matched {
+							return true, nil
+						}
+					}
+
+					// Handle standard glob pattern
+					matched, err := filepath.Match(dir, project.RelPath)
+
+					if err != nil {
+						return false, err
+					}
+
+					if matched {
+						return true, nil
+					}
+				}
+
+				// Try matching as a partial path
+				if strings.Contains(project.RelPath, dir) {
+					return true, nil
+				}
+
+				return false, nil
+			}
+
+			matched, err := matchPath(dir, project.RelPath)
+
+			if err != nil {
+				return []Project{}, err
+			}
+
+			if matched {
 				foundDirs[dir] = true
-				numMatched = numMatched + 1
+				numMatched++
 			}
 		}
 

--- a/core/dao/project_test.go
+++ b/core/dao/project_test.go
@@ -192,6 +192,7 @@ func TestProject_GetProjectsByPath(t *testing.T) {
 			{Name: "project1", Path: "/base/frontend/app1", RelPath: "frontend/app1"},
 			{Name: "project2", Path: "/base/backend/api", RelPath: "backend/api"},
 			{Name: "project3", Path: "/base/frontend/app2", RelPath: "frontend/app2"},
+			{Name: "project4", Path: "/base/frontend/nested/app3", RelPath: "frontend/nested/app3"},
 		},
 	}
 
@@ -205,13 +206,49 @@ func TestProject_GetProjectsByPath(t *testing.T) {
 			name:          "find projects in frontend path",
 			paths:         []string{"frontend"},
 			expectError:   false,
-			expectedNames: []string{"project1", "project3"},
+			expectedNames: []string{"project1", "project3", "project4"},
 		},
 		{
 			name:          "find projects with specific path",
 			paths:         []string{"frontend/app1"},
 			expectError:   false,
 			expectedNames: []string{"project1"},
+		},
+		{
+			name:          "find projects with single-level glob (1)",
+			paths:         []string{"*/app*"},
+			expectError:   false,
+			expectedNames: []string{"project1", "project3"},
+		},
+		{
+			name:          "find projects with single-level glob (2)",
+			paths:         []string{"*/app?"},
+			expectError:   false,
+			expectedNames: []string{"project1", "project3"},
+		},
+		{
+			name:          "find projects with double-star glob (1)",
+			paths:         []string{"frontend/**/app*"},
+			expectError:   false,
+			expectedNames: []string{"project1", "project3", "project4"},
+		},
+		{
+			name:          "find projects with double-star glob (2)",
+			paths:         []string{"frontend/**/app?"},
+			expectError:   false,
+			expectedNames: []string{"project1", "project3", "project4"},
+		},
+		{
+			name:          "find projects with double-star glob (3)",
+			paths:         []string{"frontend/**/**/app?"},
+			expectError:   false,
+			expectedNames: []string{"project1", "project3", "project4"},
+		},
+		{
+			name:          "find projects with double-star glob (4)",
+			paths:         []string{"**/app?"},
+			expectError:   false,
+			expectedNames: []string{"project1", "project3", "project4"},
 		},
 		{
 			name:          "find projects with non-existing path",
@@ -223,7 +260,7 @@ func TestProject_GetProjectsByPath(t *testing.T) {
 			name:          "empty paths",
 			paths:         []string{},
 			expectError:   false,
-			expectedNames: []string{"project1", "project2", "project3"},
+			expectedNames: []string{"project1", "project2", "project3", "project4"},
 		},
 	}
 


### PR DESCRIPTION
Add simple and double glob pattern support to `--paths`.

https://github.com/alajmo/mani/issues/101