### PR TITLE
Fix: stack overflow in FindFileInParentDirs on Windows

### DIFF
--- a/core/utils.go
+++ b/core/utils.go
@@ -9,7 +9,6 @@ import (
 	"os/user"
 	"path/filepath"
 	"regexp"
-	"runtime"
 	"strings"
 )
 


### PR DESCRIPTION
Fixes [#112](https://github.com/alajmo/mani/issues/112)

filepath-Dir() returns the same path when already at the filesystem root (eg, C:\), causing infinite recursion. 

### What's Changed

Added check to detect when parentDir equals path, which terminates the recursion properly.

### Technical Description

**Root Cause**
`filepath.Dir()` returns the same path when already at filesystem root 
(e.g., `C:\`), causing infinite recursion.

**Solution**
Added check `if parentDir == path` before recursing.
