### PR TITLE
test: add coverage for numeric-prefixed tag expressions (#105)

### DIFF
--- a/core/dao/tag_expr.go
+++ b/core/dao/tag_expr.go
@@ -122,7 +122,7 @@ func (l *Lexer) readTag() {
 	startPos := l.pos
 	startColumn := l.column
 
-	// First character must be a letter
+	// First character must be a valid tag start (non-reserved, non-whitespace)
 	if !isValidTagStart(l.current()) {
 		return
 	}

--- a/core/dao/tag_expr_test.go
+++ b/core/dao/tag_expr_test.go
@@ -15,6 +15,10 @@ func TestTagExpression(t *testing.T) {
 			Name: "Project B",
 			Tags: []string{"active", "sake", "backend"},
 		},
+		{
+			Name: "Project C",
+			Tags: []string{"4something", "common", "active"},
+		},
 	}
 
 	// Test cases for valid expressions
@@ -38,6 +42,14 @@ func TestTagExpression(t *testing.T) {
 		{"NOT operator", "!(active && (git || sake))", "Project B", false},
 		{"triple nested", "(((active && git) || sake) && backend)", "Project A", false},
 		{"triple nested", "(((active && git) || sake) && backend)", "Project B", true},
+
+		// Numeric-prefixed tags (regression test for gh-105)
+		{"numeric tag simple", "4something", "Project C", true},
+		{"numeric tag AND", "4something && common", "Project C", true},
+		{"numeric tag OR", "4something || backend", "Project C", true},
+		{"numeric tag NOT", "!4something", "Project C", false},
+		{"numeric tag parentheses", "(4something && common)", "Project C", true},
+		{"numeric tag no match", "4something", "Project A", false},
 	}
 
 	t.Run("valid expressions", func(t *testing.T) {


### PR DESCRIPTION
References #105.

**Code fix already merged** in `5324e76` (v0.31.2) — this PR is test-coverage backfill only, no behavior changes.

## What's tested

6 subtests in `core/dao/tag_expr_test.go` covering a numeric-prefixed tag (`4something`) across the expression grammar:

- simple tag reference
- AND expression
- OR expression
- NOT expression
- parenthesized expression
- no-match case

This locks in the behavior from the #105 fix so a future lexer/parser change can't silently regress it.

## Minor

Refreshed a stale "First character must be a letter" comment in `tag_expr.go` to match current behavior (numeric prefixes are now allowed).