### PR TITLE
fix: move wg.Add(1) before goroutine launch to prevent negative WaitGroup counter

### DIFF
--- a/core/exec/text.go
+++ b/core/exec/text.go
@@ -148,6 +148,7 @@ func RunTextCmd(
 	}
 
 	// Copy over commands STDOUT.
+	wg.Add(1)
 	go func(client Client) {
 		defer wg.Done()
 		var err error
@@ -161,9 +162,9 @@ func RunTextCmd(
 			fmt.Fprintf(stderr, "%s", err)
 		}
 	}(t.client)
-	wg.Add(1)
 
 	// Copy over tasks's STDERR.
+	wg.Add(1)
 	go func(client Client) {
 		defer wg.Done()
 		var err error
@@ -177,7 +178,6 @@ func RunTextCmd(
 			fmt.Fprintf(stderr, "%s", err)
 		}
 	}(t.client)
-	wg.Add(1)
 
 	wg.Wait()
 


### PR DESCRIPTION
## Problem

Running `mani run` with `--parallel` intermittently panics with:

```
panic: sync: negative WaitGroup counter
```

## Root Cause

In `core/exec/text.go`, the stdout/stderr copy goroutines were launched with `defer wg.Done()` **before** `wg.Add(1)` was called. If a goroutine completed before `Add(1)` executed, `Done()` would decrement the counter below zero, causing a panic.

## Fix

Move `wg.Add(1)` to before each `go func(...)` call — the standard Go pattern for WaitGroups.

Fixes #124