### PR TITLE
fix: suppress Go's *exec.ExitError leakage into task output

### DIFF
--- a/core/exec/table.go
+++ b/core/exec/table.go
@@ -1,9 +1,11 @@
 package exec
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"os/signal"
 	"strings"
 	"sync"
@@ -206,7 +208,16 @@ func RunTableCmd(t TableCmd, data dao.TableOutput, dataMutex *sync.RWMutex, wg *
 	wg.Wait()
 
 	if err := t.client.Wait(); err != nil {
-		data.Rows[t.rIndex].Columns[t.cIndex] = fmt.Sprintf("%s\n%s", data.Rows[t.rIndex].Columns[t.cIndex], err.Error())
+		// Suppress Go's *exec.ExitError ("exit status N") — it's a stdlib
+		// stringification of the process exit code that adds no information
+		// the command's own stderr (already captured above) doesn't convey,
+		// and it breaks --omit-empty-rows for commands that intentionally
+		// exit non-zero (e.g. `grep -v` with no matches). Real mani-level
+		// errors (I/O, plumbing) still surface in the cell.
+		var exitErr *exec.ExitError
+		if !errors.As(err, &exitErr) {
+			data.Rows[t.rIndex].Columns[t.cIndex] = fmt.Sprintf("%s\n%s", data.Rows[t.rIndex].Columns[t.cIndex], err.Error())
+		}
 		return err
 	}
 

--- a/core/exec/text.go
+++ b/core/exec/text.go
@@ -2,8 +2,10 @@ package exec
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"io"
+	"os/exec"
 	"strings"
 	"sync"
 
@@ -182,10 +184,16 @@ func RunTextCmd(
 	wg.Wait()
 
 	if err := t.client.Wait(); err != nil {
-		if prefix != "" {
-			fmt.Fprintf(stderr, "%s%s\n", prefix, err)
-		} else {
-			fmt.Fprintf(stderr, "%s\n", err)
+		// See table.go: suppress Go's *exec.ExitError ("exit status N");
+		// the command's own stderr was already streamed above. Real
+		// mani-level errors still print.
+		var exitErr *exec.ExitError
+		if !errors.As(err, &exitErr) {
+			if prefix != "" {
+				fmt.Fprintf(stderr, "%s%s\n", prefix, err)
+			} else {
+				fmt.Fprintf(stderr, "%s\n", err)
+			}
 		}
 
 		return err

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -2,37 +2,37 @@
 
 ## Ignoring Task Errors
 
-If you wish to continue task execution even if an error is encountered, use the flag `--ignore-errors` or specify it in the task `spec`.
+If you wish to continue task execution even if an error is encountered, use the flag `--ignore-errors` or specify it in the task `spec`. This controls whether the *remaining* commands in a multi-command task run after one of them fails on a given project.
 
-- `ignore-errors` set to false
+Assuming `task-1` exits non-zero (e.g. `false`) and `task-2` prints `bar`:
+
+- `ignore-errors` set to false (default) — task-2 is skipped after task-1 fails
 
   ```bash
   $ mani run task-1 task-2 --all --ignore-errors=false
-     Project    | Task-1        | Task-2
-    ------------+---------------+--------
-     project-0  |               |
-                | exit status 1 |
-    ------------+---------------+--------
-     project-1  |               |
-                | exit status 1 |
-    ------------+---------------+--------
-     project-2  |               |
-                | exit status 1 |
+     Project    | Task-1 | Task-2
+    ------------+--------+--------
+     project-0  |        |
+    ------------+--------+--------
+     project-1  |        |
+    ------------+--------+--------
+     project-2  |        |
   ```
 
-- `ignore-errors` set to true
+- `ignore-errors` set to true — task-2 still runs
+
   ```bash
-     Project    | Task-1        | Task-2
-    ------------+---------------+--------
-     project-0  |               | bar
-                | exit status 1 |
-    ------------+---------------+--------
-     project-1  |               | bar
-                | exit status 1 |
-    ------------+---------------+--------
-     project-2  |               | bar
-                | exit status 1 |
+  $ mani run task-1 task-2 --all --ignore-errors
+     Project    | Task-1 | Task-2
+    ------------+--------+--------
+     project-0  |        | bar
+    ------------+--------+--------
+     project-1  |        | bar
+    ------------+--------+--------
+     project-2  |        | bar
   ```
+
+> mani does not annotate cells with the OS exit code (`exit status N`). The command's own stderr is captured into the cell, so real errors from tools like `git`, `npm`, etc. still surface — only the synthetic exit‑code line is suppressed. Combine `ignore_errors` with `--omit-empty-rows` to hide rows for commands that intentionally exit non‑zero with no output (e.g. `grep -v` with no matches).
 
 ## Ignoring Non Existing Project
 


### PR DESCRIPTION
Previously, when a task command exited non-zero, mani appended Go's stdlib *exec.ExitError string ('exit status N') to the output cell (table mode) or to stderr (stream mode). This is internal Go representation leaking through — the command's own stderr is already captured separately, so the suffix added no information when failures were real, and polluted the cell when commands intentionally exited non-zero with no output (e.g. `grep -v` with no matches), breaking --omit-empty-rows.

Now mani drops the synthetic 'exit status N' line for *exec.ExitError only. Other error types (I/O failures, plumbing errors, etc.) still surface. ignore_errors semantics are unchanged: it still controls whether subsequent commands in a multi-command task run after one fails on a given project.